### PR TITLE
Add Kali GNU/Linux Rolling to compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@
 | Amazon Linux 2023 | 6.18.8-9.213.amzn2023   |
 | RHEL 10.1         | 6.12.0-124.45.1.el10_1  |
 | SUSE 16           | 6.12.0-160000.9-default |
+| Kali GNU/Linux Rolling     | 6.18.12+kali-amd64      |


### PR DESCRIPTION
I've tested it on this version of the Kali Linux kernel, and it worked fine.

I did this using a Docker container with the Ubuntu 24.04 image, but since it's Docker, the kernel is shared with the host.

<img width="1107" height="124" alt="image" src="https://github.com/user-attachments/assets/be7010f2-4055-4449-aec8-03723eeab1b8" />

<img width="186" height="57" alt="image" src="https://github.com/user-attachments/assets/90702ed7-98c1-49c3-b272-835666dd8e75" />
