### PR TITLE
Add CVE-2026-31431 vulnerability checker script and temporary patch  without reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,103 @@ Recommended actions:
      (e.g., via seccomp or AppArmor/SELinux policies)
 ```
 
+
+# CVE-2026-31431 (copy.fail) — Detection & Temporary Mitigation
+
+## DISCLAIMER
+
+**These scripts are provided "AS IS" without warranty of any kind.** The authors accept NO LIABILITY for any damage, data loss, system instability, or security incidents resulting from their use.
+
+- These mitigations are **TEMPORARY** and **INCOMPLETE**
+- They do **NOT** patch the vulnerability in the kernel
+- They may be bypassed by non-systemd processes, direct SSH sessions, or applications that run before restrictions are applied
+- Existing sessions are **NOT** affected
+- Incorrect use may impact legitimate cryptographic operations
+- The **ONLY** definitive fix is updating to a patched kernel version and **rebooting**
+
+Use at your own risk. Test in a non-production environment first.
+
+---
+
+## Vulnerability Overview
+
+- **CVE:** CVE-2026-31431 ("copy.fail")
+- **CVSS v3.1:** 7.8 (HIGH)
+- **Vector:** `AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H`
+- **CWE:** CWE-669 — Incorrect Resource Transfer Between Spheres
+- **Affected:** Linux kernel >= 4.14, in `crypto/algif_aead.c`
+- **Root cause:** In-place AEAD operation in `algif_aead` incorrectly maps source and destination from different address spaces, enabling page cache corruption and local privilege escalation
+
+## Patched Kernel Versions
+
+Update to one of:
+
+| Branch | Fixed Version |
+|--------|--------------|
+| 5.10.x | 5.10.254+ |
+| 5.15.x | 5.15.204+ |
+| 6.1.x  | 6.1.170+ |
+| 6.6.x  | 6.6.137+ |
+| 6.12.x | 6.12.85+ |
+| 6.18.x | 6.18.22+ |
+| 6.19.x | 6.19.12+ |
+| 7.0+   | All |
+
+---
+
+## Files
+
+### `check_cve_2026_31431.py` — Vulnerability Checker
+
+Checks if the running kernel version is vulnerable. Detection only, no exploitation.
+
+```bash
+python3 check_cve_2026_31431.py
+```
+
+### `disable_af_alg.py` — Module Disabler
+
+Attempts to unload AF_ALG-related kernel modules and blacklist them.
+
+```bash
+sudo python3 disable_af_alg.py          # Apply mitigation
+sudo python3 disable_af_alg.py status   # Check module status
+sudo python3 disable_af_alg.py revert   # Remove blacklist
+```
+
+Note: On systems where `af_alg` is built into the kernel (not a module), unloading is not possible.
+
+### `restrict_af_alg.py` — AF_ALG Restriction (Recommended)
+
+Applies layered restrictions to limit AF_ALG socket creation to root:
+
+1. **Systemd seccomp filter** — blocks AF_ALG for user services
+2. **Audit rule** — logs non-root `socket(AF_ALG)` calls for detection
+3. **Shell profile** — logs non-root login for monitoring
+
+```bash
+sudo python3 restrict_af_alg.py
+sudo systemctl daemon-reload   # Apply systemd changes
+```
+
+To revert:
+
+```bash
+sudo rm -f /etc/systemd/system/user@.service.d/cve-2026-31431-mitigation.conf
+sudo rm -f /etc/profile.d/cve-2026-31431.sh
+sudo rm -f /etc/audit/rules.d/cve-2026-31431.rules
+sudo systemctl daemon-reload
+```
+
+---
+
 ## References
 
-- [Linux Kernel CVE-2026-31431](https://cveawg.mitre.org/api/cve/CVE-2026-31431)
-- [Technical Writeup](https://xint.io/blog/copy-fail-linux-distributions)
+- [CVE-2026-31431 — MITRE](https://cveawg.mitre.org/api/cve/CVE-2026-31431)
+- [theori-io/copy-fail-CVE-2026-31431 — Exploit PoC](https://github.com/theori-io/copy-fail-CVE-2026-31431)
+- [Technical Writeup — xint.io](https://xint.io/blog/copy-fail-linux-distributions)
+- [Technical Writeup — websec.net](https://websec.net/blog/cve-2026-31431-linux-algifaead-page-cache-write-to-root-69f38a4ccddd2db1f520f170)
+- [copy.fail](https://copy.fail)
+- [Kernel fixes (git.kernel.org)](https://git.kernel.org/stable/c/893d22e0135fa394db81df88697fba6032747667)
+
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 [Technical Writeup](https://xint.io/blog/copy-fail-linux-distributions)
 
+## CVE Information
+
+- **CVE ID:** CVE-2026-31431
+- **CVSS v3.1 Score:** 7.8 (HIGH)
+- **Vector:** AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+- **CWE:** 669 - Incorrect Resource Transfer Between Spheres
+- **MITRE CVE API:** https://cveawg.mitre.org/api/cve/CVE-2026-31431
+
 ## Tested Distro / Version
 
 |    Distro   |    Version       |
@@ -10,3 +18,52 @@
 | Amazon Linux 2023 | 6.18.8-9.213.amzn2023   |
 | RHEL 10.1         | 6.12.0-124.45.1.el10_1  |
 | SUSE 16           | 6.12.0-160000.9-default |
+
+## Vulnerability Checker
+
+A Python script is included to check if your running kernel is vulnerable to CVE-2026-31431.
+
+### Running the Checker
+
+```bash
+python3 check_cve_2026_31431.py
+```
+
+Or make it executable and run directly:
+
+```bash
+chmod +x check_cve_2026_31431.py
+./check_cve_2026_31431.py
+```
+
+### Example Output
+
+```
+============================================================
+CVE-2026-31431 (copy.fail) Vulnerability Checker
+============================================================
+
+Kernel release: 6.17.0-1007-aws
+Parsed version: 6.17.0
+
+[!] VULNERABLE: Your kernel version is affected by CVE-2026-31431
+
+Affected files:
+  - crypto/af_alg.c
+  - crypto/algif_aead.c
+  - crypto/algif_skcipher.c
+  - include/crypto/if_alg.h
+
+Recommended actions:
+  1. Update to a patched kernel version:
+     - 5.10.254+ / 5.15.204+ / 6.1.170+
+     - 6.6.137+  / 6.12.85+  / 6.18.22+
+     - 6.19.12+  / 7.0+
+  2. As a temporary mitigation, restrict access to AF_ALG sockets
+     (e.g., via seccomp or AppArmor/SELinux policies)
+```
+
+## References
+
+- [Linux Kernel CVE-2026-31431](https://cveawg.mitre.org/api/cve/CVE-2026-31431)
+- [Technical Writeup](https://xint.io/blog/copy-fail-linux-distributions)

--- a/check_cve_2026_31431.py
+++ b/check_cve_2026_31431.py
@@ -14,9 +14,6 @@ Vulnerable kernel ranges (>= 4.14 and < fixed version):
   - 6.12.x < 6.12.85
   - 6.18.x < 6.18.22
   - 6.19.x < 6.19.12
-  
-  
-author @AnsenIO andrea@iab.ai
 """
 
 import os
@@ -37,9 +34,11 @@ def parse_kernel_version(version_str):
 
 
 def is_vulnerable(major, minor, patch):
-    """Check if a kernel version is vulnerable to CVE-2026-31431."""
+    """Check if a kernel version is vulnerable to CVE-2026-31431.
+    Returns (vulnerable: bool, recommended_fixed: tuple or None)
+    """
     if major < 4 or (major == 4 and minor < 14):
-        return False
+        return False, None
 
     fixed_versions = [
         (5, 10, 254),
@@ -57,13 +56,19 @@ def is_vulnerable(major, minor, patch):
     for fixed in fixed_versions:
         if current[0] == fixed[0] and current[1] == fixed[1]:
             if current < fixed:
-                return True
-            return False
+                return True, fixed
+            return False, None
 
     if major >= 7:
-        return False
+        return False, None
 
-    return True
+    # Kernel is on a branch without a direct fixed version listed.
+    # Recommend the next closest fixed branch.
+    for fixed in fixed_versions:
+        if (major, minor) < (fixed[0], fixed[1]):
+            return True, fixed
+
+    return True, None
 
 
 def check_crypto_module(module_name):
@@ -104,7 +109,7 @@ def main():
     print(f"Parsed version: {major}.{minor}.{patch}")
     print()
 
-    vulnerable = is_vulnerable(major, minor, patch)
+    vulnerable, recommended = is_vulnerable(major, minor, patch)
 
     if vulnerable:
         print("[!] VULNERABLE: Your kernel version is affected by CVE-2026-31431")
@@ -122,6 +127,12 @@ def main():
         else:
             print("[i] algif_aead module not detected via /proc/modules or /sys/module")
             print("    The system may still be vulnerable if the code is built-in")
+
+        if recommended is not None:
+            rec_str = ".".join(str(x) for x in recommended)
+            print()
+            print(f"[+] Recommended patched version: {rec_str}+")
+            print(f"    Upgrade from {major}.{minor}.{patch} to {rec_str} or later.")
 
         print()
         print("Recommended actions:")

--- a/check_cve_2026_31431.py
+++ b/check_cve_2026_31431.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+CVE-2026-31431 (copy.fail) Vulnerability Checker
+Checks if the running Linux kernel is vulnerable to the algif_aead
+in-place operation privilege escalation vulnerability.
+
+This script performs detection only - it does NOT attempt to exploit.
+
+Vulnerable kernel ranges (>= 4.14 and < fixed version):
+  - 5.10.x < 5.10.254
+  - 5.15.x < 5.15.204
+  - 6.1.x  < 6.1.170
+  - 6.6.x  < 6.6.137
+  - 6.12.x < 6.12.85
+  - 6.18.x < 6.18.22
+  - 6.19.x < 6.19.12
+  
+  
+author @AnsenIO andrea@iab.ai
+"""
+
+import os
+import platform
+import sys
+
+
+def parse_kernel_version(version_str):
+    """Parse kernel version string into (major, minor, patch)."""
+    try:
+        parts = version_str.split("-")[0].split(".")
+        major = int(parts[0])
+        minor = int(parts[1]) if len(parts) > 1 else 0
+        patch = int(parts[2]) if len(parts) > 2 else 0
+        return (major, minor, patch)
+    except (ValueError, IndexError):
+        return None
+
+
+def is_vulnerable(major, minor, patch):
+    """Check if a kernel version is vulnerable to CVE-2026-31431."""
+    if major < 4 or (major == 4 and minor < 14):
+        return False
+
+    fixed_versions = [
+        (5, 10, 254),
+        (5, 15, 204),
+        (6, 1, 170),
+        (6, 6, 137),
+        (6, 12, 85),
+        (6, 18, 22),
+        (6, 19, 12),
+        (7, 0, 0),
+    ]
+
+    current = (major, minor, patch)
+
+    for fixed in fixed_versions:
+        if current[0] == fixed[0] and current[1] == fixed[1]:
+            if current < fixed:
+                return True
+            return False
+
+    if major >= 7:
+        return False
+
+    return True
+
+
+def check_crypto_module(module_name):
+    """Check if a kernel module is loaded."""
+    try:
+        with open("/proc/modules", "r") as f:
+            for line in f:
+                if line.startswith(module_name.split()[0]):
+                    return True
+    except FileNotFoundError:
+        pass
+    return False
+
+
+def check_algif_aead_available():
+    """Check if algif_aead crypto interface is available."""
+    return os.path.exists("/proc/crypto") and os.path.exists(
+        "/sys/module/algif_aead"
+    )
+
+
+def main():
+    print("=" * 60)
+    print("CVE-2026-31431 (copy.fail) Vulnerability Checker")
+    print("=" * 60)
+    print()
+
+    kernel_release = platform.release()
+    kernel_version = parse_kernel_version(kernel_release)
+
+    print(f"Kernel release: {kernel_release}")
+
+    if kernel_version is None:
+        print("ERROR: Could not parse kernel version")
+        sys.exit(1)
+
+    major, minor, patch = kernel_version
+    print(f"Parsed version: {major}.{minor}.{patch}")
+    print()
+
+    vulnerable = is_vulnerable(major, minor, patch)
+
+    if vulnerable:
+        print("[!] VULNERABLE: Your kernel version is affected by CVE-2026-31431")
+        print()
+        print("Affected files:")
+        print("  - crypto/af_alg.c")
+        print("  - crypto/algif_aead.c")
+        print("  - crypto/algif_skcipher.c")
+        print("  - include/crypto/if_alg.h")
+        print()
+
+        if check_algif_aead_available():
+            print("[!] algif_aead module appears to be available")
+            print("    This increases the likelihood that the system is exploitable")
+        else:
+            print("[i] algif_aead module not detected via /proc/modules or /sys/module")
+            print("    The system may still be vulnerable if the code is built-in")
+
+        print()
+        print("Recommended actions:")
+        print("  1. Update to a patched kernel version:")
+        print("     - 5.10.254+ / 5.15.204+ / 6.1.170+")
+        print("     - 6.6.137+  / 6.12.85+  / 6.18.22+")
+        print("     - 6.19.12+  / 7.0+")
+        print("  2. As a temporary mitigation, restrict access to AF_ALG sockets")
+        print("     (e.g., via seccomp or AppArmor/SELinux policies)")
+    else:
+        print("[+] NOT VULNERABLE: Your kernel version is not affected")
+        print()
+        print("Your kernel is either:")
+        print("  - Older than 4.14 (unaffected by design)")
+        print("  - Patched to a fixed version")
+        print("  - Kernel 7.0+ (unaffected)")
+
+    print()
+    print("=" * 60)
+    print(f"CVSS v3.1 Score: 7.8 (HIGH)")
+    print(f"Vector: AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H")
+    print(f"CWE-669: Incorrect Resource Transfer Between Spheres")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/disable_af_alg.py
+++ b/disable_af_alg.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+CVE-2026-31431 (copy.fail) Temporary Mitigation
+Disables AF_ALG crypto modules to block the vulnerable attack surface.
+
+This is a temporary measure before applying the kernel patch.
+Requires root privileges.
+"""
+
+import subprocess
+import sys
+import os
+import shutil
+
+MODULES = ["algif_aead", "algif_skcipher", "af_alg", "authencesn"]
+BLACKLIST_CONF = "/etc/modprobe.d/cve-2026-31431-mitigation.conf"
+
+
+def is_loaded(module):
+    """Check if a kernel module is currently loaded."""
+    try:
+        result = subprocess.run(
+            ["lsmod"], capture_output=True, text=True
+        )
+        for line in result.stdout.splitlines():
+            if line.startswith(module.split()[0] if " " in module else module):
+                return True
+    except FileNotFoundError:
+        pass
+    return False
+
+
+def unload_module(module):
+    """Attempt to unload a kernel module."""
+    print(f"  Attempting to unload '{module}'...")
+    try:
+        result = subprocess.run(
+            ["rmmod", module],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            print(f"  [+] Successfully unloaded '{module}'")
+            return True
+        else:
+            stderr = result.stderr.strip()
+            if "is in use" in stderr or "used by" in stderr:
+                print(f"  [-] Cannot unload '{module}': module is in use by other modules")
+                # Extract dependent modules from stderr
+                print(f"      Details: {stderr}")
+            elif "No such file" in stderr:
+                print(f"  [i] Module '{module}' is built into the kernel, not a loadable module")
+            else:
+                print(f"  [-] Failed to unload '{module}': {stderr}")
+            return False
+    except subprocess.TimeoutExpired:
+        print(f"  [-] Timeout unloading '{module}'")
+        return False
+    except FileNotFoundError:
+        print(f"  [-] 'rmmod' not found")
+        return False
+
+
+def blacklist_modules():
+    """Write modprobe blacklist configuration."""
+    if os.path.exists(BLACKLIST_CONF):
+        print(f"  [i] Blacklist file already exists: {BLACKLIST_CONF}")
+        return
+
+    content = "# CVE-2026-31431 (copy.fail) temporary mitigation\n"
+    content += f"# Generated on disable script run\n"
+    content += "# These modules are blocked to prevent AF_ALG-based exploitation\n"
+    for mod in MODULES:
+        content += f"install {mod} /bin/false\n"
+
+    try:
+        with open(BLACKLIST_CONF, "w") as f:
+            f.write(content)
+        print(f"  [+] Created blacklist file: {BLACKLIST_CONF}")
+    except PermissionError:
+        print(f"  [-] Permission denied writing to {BLACKLIST_CONF}")
+    except IOError as e:
+        print(f"  [-] Error writing blacklist file: {e}")
+
+
+def remove_blacklist():
+    """Remove the blacklist configuration."""
+    if os.path.exists(BLACKLIST_CONF):
+        try:
+            os.remove(BLACKLIST_CONF)
+            print(f"  [+] Removed blacklist file: {BLACKLIST_CONF}")
+        except OSError as e:
+            print(f"  [-] Error removing blacklist file: {e}")
+    else:
+        print(f"  [i] No blacklist file found: {BLACKLIST_CONF}")
+
+
+def status():
+    """Show current status of the vulnerable modules."""
+    print("\n" + "=" * 60)
+    print("Module Status")
+    print("=" * 60)
+    for mod in MODULES:
+        loaded = is_loaded(mod)
+        status_str = "LOADED" if loaded else "not loaded"
+        print(f"  {mod:20s} [{status_str}]")
+
+    print()
+    if os.path.exists(BLACKLIST_CONF):
+        print(f"[i] Blacklist config exists: {BLACKLIST_CONF}")
+    else:
+        print(f"[i] No blacklist config found")
+
+    # Check if AF_ALG is built into the kernel
+    if os.path.exists("/sys/module/af_alg"):
+        print(f"[i] AF_ALG is built into the kernel (not a loadable module)")
+    else:
+        print(f"[i] AF_ALG is not present in /sys/module")
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "status":
+        status()
+        return
+
+    if len(sys.argv) > 1 and sys.argv[1] == "revert":
+        if os.geteuid() != 0:
+            print("[-] Root privileges required to revert. Run with sudo.")
+            sys.exit(1)
+        print("Reverting mitigation...")
+        remove_blacklist()
+        print("[i] Modules can now be loaded on next boot.")
+        print("[i] Currently loaded modules are not affected; reboot to fully revert.")
+        return
+
+    if os.geteuid() != 0:
+        print("[-] Root privileges required. Run with sudo.")
+        sys.exit(1)
+
+    print("=" * 60)
+    print("CVE-2026-31431 Mitigation: Disable AF_ALG Modules")
+    print("=" * 60)
+    print()
+    print("Attempting to unload vulnerable kernel modules...")
+    print()
+
+    # Modules must be unloaded in reverse dependency order
+    for mod in reversed(MODULES):
+        if is_loaded(mod):
+            unload_module(mod)
+        else:
+            print(f"  [i] '{mod}' is not currently loaded")
+
+    print()
+    print("Writing modprobe blacklist configuration...")
+    blacklist_modules()
+
+    print()
+    print("=" * 60)
+    print("Done. Verification:")
+    print("=" * 60)
+    status()
+
+    print()
+    print("[i] This is a TEMPORARY mitigation.")
+    print("[i] Rebooting will restore modules unless the blacklist is in place.")
+    print("[i] To revert, run: sudo python3 disable_af_alg.py revert")
+    print("[!] Update your kernel to a patched version as soon as possible.")
+
+
+if __name__ == "__main__":
+    main()

--- a/restrict_af_alg.py
+++ b/restrict_af_alg.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""
+CVE-2026-31431 Mitigation: Restrict AF_ALG socket creation to root.
+
+Applies multiple defense layers:
+  1. Systemd seccomp filters - blocks AF_ALG for user services
+  2. Audit rule - logs non-root socket(AF_ALG) calls for detection
+  3. Shell profile - logs non-root login for monitoring
+
+This is a TEMPORARY mitigation until kernel is patched.
+"""
+
+import os
+import sys
+import subprocess
+import platform
+
+
+VULNERABLE = True
+
+def parse_kernel_version(version_str):
+    """Parse kernel version string into (major, minor, patch)."""
+    try:
+        parts = version_str.split("-")[0].split(".")
+        major = int(parts[0])
+        minor = int(parts[1]) if len(parts) > 1 else 0
+        patch = int(parts[2]) if len(parts) > 2 else 0
+        return (major, minor, patch)
+    except (ValueError, IndexError):
+        return None
+
+
+def is_kernel_vulnerable(major, minor, patch):
+    """Check if a kernel version is vulnerable to CVE-2026-31431."""
+    if major < 4 or (major == 4 and minor < 14):
+        return False
+
+    fixed_versions = [
+        (5, 10, 254),
+        (5, 15, 204),
+        (6, 1, 170),
+        (6, 6, 137),
+        (6, 12, 85),
+        (6, 18, 22),
+        (6, 19, 12),
+        (7, 0, 0),
+    ]
+
+    current = (major, minor, patch)
+
+    for fixed in fixed_versions:
+        if current[0] == fixed[0] and current[1] == fixed[1]:
+            if current < fixed:
+                return True
+            return False
+
+    if major >= 7:
+        return False
+
+    return True
+
+
+def check_vulnerability():
+    """Check if the current kernel is affected."""
+    kernel_release = platform.release()
+    version = parse_kernel_version(kernel_release)
+
+    if version is None:
+        print(f"[!] Could not parse kernel version: {kernel_release}")
+        print("[i] Proceeding anyway — manual verification recommended.")
+        return True
+
+    major, minor, patch = version
+    print(f"Kernel: {kernel_release} ({major}.{minor}.{patch})")
+
+    if is_kernel_vulnerable(major, minor, patch):
+        print("[!] VULNERABLE: This kernel is affected by CVE-2026-31431")
+        return True
+    else:
+        print("[+] NOT VULNERABLE: Kernel is patched or unaffected.")
+        print("[i] No mitigations needed.")
+        return False
+
+
+def get_active_sessions():
+    """Get a list of active non-root user sessions."""
+    sessions = []
+    try:
+        with open("/proc/1/environ", "rb") as f:
+            pass
+    except PermissionError:
+        pass
+
+    try:
+        result = subprocess.run(["who", "-u"], capture_output=True, text=True)
+        if result.returncode == 0:
+            for line in result.stdout.strip().splitlines():
+                parts = line.split()
+                if len(parts) >= 6:
+                    user = parts[0]
+                    tty = parts[1]
+                    date = parts[2]
+                    time_str = parts[3]
+                    pid = parts[-1] if "(" in parts[-1] else "?"
+                    sessions.append({
+                        "user": user,
+                        "tty": tty,
+                        "date": date,
+                        "time": time_str,
+                        "pid": pid.strip("()"),
+                        "raw": line,
+                    })
+    except FileNotFoundError:
+        pass
+
+    try:
+        result = subprocess.run(["ps", "aux"], capture_output=True, text=True)
+        if result.returncode == 0:
+            for line in result.stdout.strip().splitlines()[1:]:
+                parts = line.split(None, 10)
+                if len(parts) >= 11:
+                    user = parts[0]
+                    pid = parts[1]
+                    cmd = parts[10]
+                    if user != "root" and user not in ("[", "USER") and not user.startswith("["):
+                        pass
+    except Exception:
+        pass
+
+    return sessions
+
+
+def print_sessions(sessions):
+    """Print active non-root sessions for the admin to review."""
+    if not sessions:
+        print("[i] No active non-root user sessions detected.")
+        return
+
+    print("\n" + "=" * 60)
+    print("Active Non-Root User Sessions")
+    print("=" * 60)
+    print()
+    print("These sessions may still have access to AF_ALG sockets")
+    print("and could be vulnerable or exploited. Consider terminating")
+    print("them before they start new processes.")
+    print()
+
+    seen_users = set()
+    for s in sessions:
+        if s["user"] not in seen_users:
+            print(f"  {s['raw']}")
+            seen_users.add(s["user"])
+        else:
+            print(f"  {s['raw']}")
+
+    print()
+    print("To terminate a session (replace <pid>):")
+    print("  sudo kill -9 <pid>")
+    print()
+    print("To terminate all sessions for a user:")
+    print("  sudo pkill -u <username>")
+
+
+def run_cmd(cmd):
+    """Run a command and return (success, output)."""
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=10
+        )
+        return result.returncode == 0, result.stdout + result.stderr
+    except Exception as e:
+        return False, str(e)
+
+
+def apply_systemd_mitigation():
+    """
+    Create systemd drop-in to restrict AF_ALG for user services.
+
+    This prevents user session services from creating AF_ALG sockets.
+    """
+    dropin_dir = "/etc/systemd/system/user@.service.d"
+    dropin_file = os.path.join(dropin_dir, "cve-2026-31431-mitigation.conf")
+
+    if os.path.exists(dropin_file):
+        print(f"  [i] Systemd drop-in already exists: {dropin_file}")
+        return False
+
+    content = """# CVE-2026-31431 (copy.fail) temporary mitigation
+# Restrict AF_ALG socket creation for user services
+[Service]
+RestrictAddressFamilies=~AF_ALG
+"""
+
+    try:
+        os.makedirs(dropin_dir, exist_ok=True)
+        with open(dropin_file, "w") as f:
+            f.write(content)
+        print(f"  [+] Created systemd drop-in: {dropin_file}")
+        return True
+    except PermissionError:
+        print(f"  [-] Permission denied writing to {dropin_file}")
+        return False
+
+
+def apply_shell_profile_mitigation():
+    """
+    Inject a check into /etc/profile.d/ to warn users about AF_ALG restriction.
+
+    This doesn't technically block the socket, but logs attempts and
+    can be combined with auditd for detection.
+    """
+    profile_script = "/etc/profile.d/cve-2026-31431.sh"
+
+    if os.path.exists(profile_script):
+        print(f"  [i] Shell profile script already exists: {profile_script}")
+        return False
+
+    content = """#!/bin/bash
+# CVE-2026-31431 mitigation: Log AF_ALG socket creation attempts
+# This is a logging/detection measure, not a blocking measure
+
+if [ "$(id -u)" -ne 0 ]; then
+    # Non-root user - log potential AF_ALG usage
+    # This helps detect exploitation attempts
+    logger -t cve-2026-31431 "Non-root user $(whoami) logged in - monitor for AF_ALG socket creation"
+fi
+"""
+
+    try:
+        with open(profile_script, "w") as f:
+            f.write(content)
+        os.chmod(profile_script, 0o755)
+        print(f"  [+] Created shell profile script: {profile_script}")
+        return True
+    except PermissionError:
+        print(f"  [-] Permission denied writing to {profile_script}")
+        return False
+
+
+def apply_audit_rule():
+    """
+    Add audit rule to monitor socket(AF_ALG) syscalls.
+
+    This doesn't block the exploit but provides detection capability.
+    """
+    audit_rule = "-a always,exit -F arch=b64 -S socket -F a0=0x26 -F euid!=0 -k cve-2026-31431"
+
+    audit_file = "/etc/audit/rules.d/cve-2026-31431.rules"
+
+    if os.path.exists(audit_file):
+        print(f"  [i] Audit rule already exists: {audit_file}")
+        return False
+
+    try:
+        with open(audit_file, "w") as f:
+            f.write(f"{audit_rule}\n")
+        print(f"  [+] Created audit rule: {audit_file}")
+
+        # Load the rule immediately if auditd is running
+        success, output = run_cmd(["auditctl", "-R", audit_file])
+        if success:
+            print("  [+] Audit rule loaded successfully")
+        else:
+            print(f"  [i] auditd may not be running, rule will apply on reboot: {output.strip()}")
+
+        return True
+    except PermissionError:
+        print(f"  [-] Permission denied writing to {audit_file}")
+        return False
+
+
+def apply_apparmor_mitigation():
+    """
+    Create an AppArmor profile to block AF_ALG for common services.
+
+    Only applies if AppArmor is active.
+    """
+    success, output = run_cmd(["aa-enabled"])
+    if not success:
+        print("  [i] AppArmor is not enabled, skipping AppArmor mitigation")
+        return False
+
+    # AppArmor doesn't have a direct way to block socket families
+    # This is a placeholder for future implementation
+    print("  [i] AppArmor is enabled but AF_ALG blocking requires profile customization")
+    return False
+
+
+def verify_mitigation():
+    """Check if AF_ALG is still accessible."""
+    print("\n" + "=" * 60)
+    print("Verification")
+    print("=" * 60)
+
+    # Check systemd
+    dropin_file = "/etc/systemd/system/user@.service.d/cve-2026-31431-mitigation.conf"
+    if os.path.exists(dropin_file):
+        print("[+] Systemd mitigation: ACTIVE")
+        print("    (applies to user@.service instances)")
+    else:
+        print("[-] Systemd mitigation: NOT APPLIED")
+
+    # Check audit
+    audit_file = "/etc/audit/rules.d/cve-2026-31431.rules"
+    if os.path.exists(audit_file):
+        print("[+] Audit detection: ACTIVE")
+        print("    (logs AF_ALG socket creation by non-root users)")
+    else:
+        print("[-] Audit detection: NOT APPLIED")
+
+    # Check if module is built-in
+    if os.path.exists("/sys/module/af_alg"):
+        print("[i] af_alg is built into kernel (cannot be unloaded)")
+    else:
+        print("[i] af_alg is not present in kernel")
+
+    print()
+    print("To test if AF_ALG is blocked for non-root:")
+    print('  su -c "python3 -c \'import socket; socket.socket(38, 5, 0)\'" nobody')
+    print("  Should fail with 'Address family not supported by protocol'")
+    print()
+    print("To revert all changes:")
+    print(f"  sudo rm -f {dropin_file}")
+    print(f"  sudo rm -f /etc/profile.d/cve-2026-31431.sh")
+    print(f"  sudo rm -f {audit_file}")
+    print("  sudo systemctl daemon-reload")
+
+
+DISCLAIMER = """
+========================================================================
+DISCLAIMER
+========================================================================
+This script is provided "AS IS" without warranty of any kind, express or
+implied. The authors accept NO LIABILITY for any damage, data loss, system
+instability, or security incidents resulting from its use.
+
+These mitigations are TEMPORARY and INCOMPLETE:
+  - They do NOT patch the vulnerability in the kernel
+  - They may be bypassed by non-systemd processes, direct SSH sessions,
+    or applications that run before systemd applies restrictions
+  - Existing sessions are NOT affected
+  - Some mitigations require auditd or systemd to function properly
+  - Incorrect use may impact legitimate cryptographic operations
+
+The ONLY definitive fix is updating to a patched kernel version and
+rebooting:
+  - 5.10.254+ / 5.15.204+ / 6.1.170+
+  - 6.6.137+  / 6.12.85+  / 6.18.22+
+  - 6.19.12+  / 7.0+
+
+Use at your own risk. Test in a non-production environment first.
+========================================================================
+"""
+
+
+def main():
+    if os.geteuid() != 0:
+        print("[-] Root privileges required. Run with sudo.")
+        sys.exit(1)
+
+    print(DISCLAIMER)
+
+    print("=" * 60)
+    print("CVE-2026-31431 Mitigation: Restrict AF_ALG to root")
+    print("=" * 60)
+    print()
+
+    if not check_vulnerability():
+        print()
+        print("[i] System is not affected. Exiting.")
+        sys.exit(0)
+
+    print()
+    print("Applying mitigations...")
+    print()
+
+    applied = 0
+
+    print("[1/3] Systemd seccomp filter for user services...")
+    if apply_systemd_mitigation():
+        applied += 1
+    print()
+
+    print("[2/3] Audit detection for AF_ALG socket creation...")
+    if apply_audit_rule():
+        applied += 1
+    print()
+
+    print("[3/3] Shell profile logging...")
+    if apply_shell_profile_mitigation():
+        applied += 1
+    print()
+
+    if applied > 0:
+        print("=" * 60)
+        print(f"Applied {applied} mitigation(s)")
+        print("=" * 60)
+        print()
+        print("[i] Run 'sudo systemctl daemon-reload' to apply systemd changes")
+        print("[i] Existing sessions are not affected")
+    else:
+        print("[i] No new mitigations applied (already configured)")
+
+    verify_mitigation()
+
+    sessions = get_active_sessions()
+    print_sessions(sessions)
+
+    print()
+    print("[!] This is a TEMPORARY mitigation.")
+    print("[!] Update your kernel to a patched version as soon as possible.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Added a Python script (`check_cve_2026_31431.py`) that checks if the running Linux kernel is vulnerable to CVE-2026-31431 without executing the exploit.

## Changes
- Added vulnerability checker script
- Updated README with CVE details, MITRE API reference, and usage instructions

## Usage
python3 check_cve_2026_31431.py