### PR TITLE
Add workaround using eBPF for systems that can not be rebooted

### DIFF
--- a/workaround.py
+++ b/workaround.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+disable_af_alg.py - BCC port of disable_af_alg.stp
+
+Blocks creation of AF_ALG (38) sockets by SIGKILLing the caller
+via bpf_send_signal().
+
+Requirements:
+  - Linux kernel >= 5.3 (bpf_send_signal helper)
+  - root
+  - bcc / python3-bpfcc
+
+Author:
+ - baonq5
+ - giangnnq
+"""
+
+from bcc import BPF
+import ctypes as ct
+import sys
+
+BPF_TEXT = r"""
+#include <uapi/linux/ptrace.h>
+#include <linux/sched.h>
+
+#define AF_ALG 38
+
+BPF_ARRAY(blocked_count, u64, 1);
+
+struct event_t {
+    u32  pid;
+    int  family;
+    int  type;
+    int  proto;
+    u64  count;
+    char comm[TASK_COMM_LEN];
+};
+
+BPF_PERF_OUTPUT(events);
+
+/*
+ * __sys_socket() is the in-kernel helper invoked by every
+ * arch-specific syscall entry stub (__x64_sys_socket,
+ * __arm64_sys_socket, __ia32_sys_socket, ...). Probing it once
+ * covers all architectures with a plain C ABI.
+ */
+int kprobe____sys_socket(struct pt_regs *ctx, int family, int type, int protocol)
+{
+    if (family != AF_ALG)
+        return 0;
+
+    u32 key = 0;
+    u64 init = 1, *cnt;
+    u64 n = 1;
+
+    cnt = blocked_count.lookup_or_try_init(&key, &init);
+    if (cnt)
+        n = __sync_fetch_and_add(cnt, 1) + 1;
+
+    struct event_t evt = {};
+    evt.pid    = bpf_get_current_pid_tgid() >> 32;
+    evt.family = family;
+    evt.type   = type;
+    evt.proto  = protocol;
+    evt.count  = n;
+    bpf_get_current_comm(&evt.comm, sizeof(evt.comm));
+    events.perf_submit(ctx, &evt, sizeof(evt));
+
+    /* Equivalent of stap's raise(9) - SIGKILL the offending task. */
+    bpf_send_signal(9);
+    return 0;
+}
+"""
+
+def main():
+    b = BPF(text=BPF_TEXT)
+    try:
+        b.attach_kprobe(event="__sys_socket", fn_name="kprobe____sys_socket")
+    except Exception as e:
+        print(f"[disable_af_alg] failed to attach kprobe on __sys_socket: {e}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    print("[disable_af_alg] Blocking AF_ALG via kprobe on __sys_socket... Ctrl-C to exit")
+
+    def on_event(cpu, data, size):
+        e = b["events"].event(data)
+        print(f"[disable_af_alg] blocked[{e.count}] pid={e.pid} "
+              f"comm={e.comm.decode('utf-8', 'replace')} "
+              f"at __sys_socket type={e.type} proto={e.proto}")
+
+    b["events"].open_perf_buffer(on_event)
+
+    try:
+        while True:
+            b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        pass
+
+    total = b["blocked_count"][ct.c_int(0)].value
+    print(f"\n[disable_af_alg] exiting (blocked={total})")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Overview

This PR add a workaround that use eBPF (require `bcc/python3-bpfcc`) to intercept processes creating AF_ALG sockets (socket family 38), then immediately SIGKILLs (terminates) the calling process. Tested on `Rocky 9.3` using linux kernel version `5.14.0-362.18.1.el9_3.x86_64`

Inspired by mattmix's systemtap script at https://github.com/theori-io/copy-fail-CVE-2026-31431/issues/30#issuecomment-4349469616

## How to

Running

<img width="1462" height="232" alt="CleanShot 2026-05-04 at 15 47 14@2x" src="https://github.com/user-attachments/assets/f4c4cbdc-771d-41df-8344-b8b06fdd1848" />

The test script is killed before having any chance

<img width="976" height="152" alt="CleanShot 2026-05-04 at 15 47 49@2x" src="https://github.com/user-attachments/assets/387039ab-1c45-42e5-bbe8-7ddcc1135741" />
