### PR TITLE
added mitigation steps in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,27 @@
 | Amazon Linux 2023 | 6.18.8-9.213.amzn2023   |
 | RHEL 10.1         | 6.12.0-124.45.1.el10_1  |
 | SUSE 16           | 6.12.0-160000.9-default |
+
+
+
+# Mitigation
+
+Red Hat has published product-specific guidance for several platforms including RHEL, OpenShift 4, ROSA/OpenShift Dedicated, ARO, and ACM Governance Policy — links to each are in the official advisory.
+For general mitigation applicable to most systems:
+
+⚠️ Note: These changes may affect performance on workloads that rely on kernel cryptographic functions.
+
+Since the vulnerable kernel module cannot be blacklisted directly, you can instead disable the specific functions it exposes. Add one of the following to your kernel boot arguments:
+## Option 1 — Disable only the AEAD algorithm interface:
+```
+initcall_blacklist=algif_aead_init
+```
+## Option 2 — Disable the entire AF_ALG socket interface (broader impact):
+```
+initcall_blacklist=af_alg_init
+```
+## Option 3 — Disable only the specific vulnerable algorithm:
+```
+initcall_blacklist=crypto_authenc_esn_module_init
+```
+Option 3 is the most targeted and least likely to cause side effects. Option 2 is the most aggressive and will block all kernel crypto socket operations, so use it only if you don't rely on AF_ALG for anything else.


### PR DESCRIPTION
Add mitigation for XFRM/AF_ALG kernel crypto exploit
Adds mitigation steps for the algif_aead / crypto_authenc_esn kernel vulnerability that allows unprivileged users to abuse the AF_ALG socket interface for privilege escalation.
Changes include:

Mitigation guide with three kernel boot argument options ranked by impact
Notes on potential performance implications for crypto-dependent workloads
References to upstream Red Hat advisories for affected platforms